### PR TITLE
Refactor assessment flow with Gemini analysis

### DIFF
--- a/src/components/PreAssessmentScreen.tsx
+++ b/src/components/PreAssessmentScreen.tsx
@@ -1,12 +1,12 @@
-﻿// src/components/PreAssessmentScreen.tsx
+// src/components/PreAssessmentScreen.tsx
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
+import { Clock, ListChecks } from 'lucide-react';
 import { Button } from './ui/button';
 import { useToast } from './ui/use-toast';
 import { useLanguage } from '../hooks/useLanguage';
-import { Clock, ListChecks } from 'lucide-react';
 import { getAssessment, ensureProfile, startAssessmentAttempt } from '../lib/api';
-import { Role, Assessment } from '../types/assessment';
+import type { Role, Assessment } from '../types/assessment';
 import { useAuth } from '@/contexts/AuthContext';
 import { useAssessment } from '@/contexts/AssessmentContext';
 
@@ -67,17 +67,7 @@ const PreAssessmentScreen: React.FC<PreAssessmentScreenProps> = ({ role, onStart
         totalQuestions: assessment.questions.length,
       });
 
-      setActiveAttempt({
-        id: attempt.id,
-        status: attempt.status,
-        answeredCount: attempt.answeredCount,
-        totalQuestions: attempt.totalQuestions,
-        progressPercent: attempt.progressPercent,
-        startedAt: attempt.startedAt,
-        submittedAt: attempt.submittedAt,
-        completedAt: attempt.completedAt,
-        lastActivityAt: attempt.lastActivityAt,
-      });
+      setActiveAttempt(attempt);
 
       onStartAssessment(assessment);
     } catch (attemptError) {

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -3,20 +3,24 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { Button } from './ui/button';
 import { useLanguage } from '../hooks/useLanguage';
+import type { AssessmentResult } from '@/types/assessment';
 
 interface ResultScreenProps {
-  // Define props with correct types
-  result: {
-    score: number;
-    strengths: string[];
-  };
-  onTryoutClick: () => void;
+  result: AssessmentResult;
+  onScheduleInterview: () => void;
 }
 
-const ResultScreen: React.FC<ResultScreenProps> = ({ result, onTryoutClick }) => {
+const ResultScreen: React.FC<ResultScreenProps> = ({ result, onScheduleInterview }) => {
   const { t } = useLanguage();
-  const { score, strengths } = result;
-  const isAPlayer = score >= 80;
+
+  const overallScore = result.overallScore ?? 0;
+  const adjustedScore = result.adjustedScore;
+  const hasCheating = result.cheatingCount > 0;
+  const scoreToDisplay = hasCheating ? adjustedScore : overallScore;
+  const summary = result.summary ?? result.aiSummary ?? '';
+  const strengths = result.strengths ?? [];
+  const weaknesses = result.weaknesses ?? [];
+  const skillEntries = Object.entries(result.skillScores ?? {});
 
   return (
     <motion.div
@@ -30,39 +34,94 @@ const ResultScreen: React.FC<ResultScreenProps> = ({ result, onTryoutClick }) =>
       <h2 className="text-3xl font-bold mb-3 tracking-tight">{t('resultScreen.title')}</h2>
       <p className="text-muted-foreground mb-8">{t('resultScreen.subtitle')}</p>
 
-      <div className="mb-8">
-        <h3 className="font-semibold text-lg mb-4">{t('resultScreen.strengthsTitle')}</h3>
-        <div className="flex justify-center flex-wrap gap-4">
-          {strengths.map((strength, index) => (
-            <div key={index} className="bg-green-100 text-green-800 font-medium px-4 py-2 rounded-full">
-              {strength}
-            </div>
-          ))}
+      <div className="grid gap-4 md:grid-cols-3 mb-8">
+        <div className="bg-blue-50 text-blue-800 rounded-2xl p-4">
+          <p className="text-sm font-semibold mb-1">{t('resultScreen.completedQuestions')}</p>
+          <p className="text-3xl font-bold">{result.completedCount}</p>
+        </div>
+        <div className="bg-green-50 text-green-800 rounded-2xl p-4">
+          <p className="text-sm font-semibold mb-1">
+            {hasCheating ? t('resultScreen.adjustedScore') : t('resultScreen.overallScore')}
+          </p>
+          <p className="text-3xl font-bold">{scoreToDisplay}</p>
+          {hasCheating ? (
+            <p className="text-xs mt-2 text-green-700">
+              {t('resultScreen.adjustedScoreNotice', { base: overallScore, adjusted: adjustedScore })}
+            </p>
+          ) : null}
+        </div>
+        <div className="bg-purple-50 text-purple-800 rounded-2xl p-4">
+          <p className="text-sm font-semibold mb-1">{t('resultScreen.cheatingCount')}</p>
+          <p className="text-3xl font-bold">{result.cheatingCount}</p>
         </div>
       </div>
 
-      <div className="mt-8 pt-8 border-t border-border/80">
-        <h3 className="font-semibold text-xl mb-2 tracking-tight">{t('resultScreen.nextStepsTitle')}</h3>
-        {isAPlayer ? (
-          <div>
-            <p className="text-muted-foreground my-6 text-lg">
-              {t('resultScreen.successText')}
-            </p>
-            <Button className="apple-button mt-4">
-              {t('resultScreen.successCta')}
-            </Button>
+      {hasCheating ? (
+        <div className="mb-8 p-4 rounded-2xl border border-red-200 bg-red-50 text-red-700">
+          {t('resultScreen.cheatingWarning', { count: result.cheatingCount })}
+        </div>
+      ) : null}
+
+      <div className="grid gap-6 md:grid-cols-2 mb-8 text-left">
+        <div>
+          <h3 className="font-semibold text-lg mb-3">{t('resultScreen.strengthsTitle')}</h3>
+          <div className="flex flex-wrap gap-3">
+            {strengths.length > 0
+              ? strengths.map((strength, index) => (
+                  <span key={index} className="bg-green-100 text-green-800 font-medium px-4 py-2 rounded-full">
+                    {strength}
+                  </span>
+                ))
+              : (
+                <p className="text-sm text-muted-foreground">{t('resultScreen.noStrengths')}</p>
+                )}
           </div>
-        ) : (
-          <div>
-            <p className="text-muted-foreground my-6 text-lg">
-              {t('resultScreen.tryoutText')}
-            </p>
-            <Button onClick={onTryoutClick} className="apple-button mt-4">
-              {t('resultScreen.tryoutCta')}
-            </Button>
+        </div>
+        <div>
+          <h3 className="font-semibold text-lg mb-3">{t('resultScreen.weaknessesTitle')}</h3>
+          <div className="flex flex-wrap gap-3">
+            {weaknesses.length > 0
+              ? weaknesses.map((weakness, index) => (
+                  <span key={index} className="bg-orange-100 text-orange-800 font-medium px-4 py-2 rounded-full">
+                    {weakness}
+                  </span>
+                ))
+              : (
+                <p className="text-sm text-muted-foreground">{t('resultScreen.noWeaknesses')}</p>
+                )}
           </div>
-        )}
+        </div>
       </div>
+
+      {skillEntries.length > 0 ? (
+        <div className="mb-8 text-left">
+          <h3 className="font-semibold text-lg mb-3">{t('resultScreen.skillScoresTitle')}</h3>
+          <div className="grid gap-3 md:grid-cols-2">
+            {skillEntries.map(([skill, score]) => (
+              <div
+                key={skill}
+                className="flex items-center justify-between rounded-xl border border-gray-200 px-4 py-3"
+              >
+                <span className="font-medium text-gray-700">{skill}</span>
+                <span className="text-gray-900 font-semibold">{score}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="text-left mb-8">
+        <h3 className="font-semibold text-lg mb-3">{t('resultScreen.analysisSummaryTitle')}</h3>
+        <p className="text-muted-foreground leading-relaxed whitespace-pre-line">{summary}</p>
+      </div>
+
+      <div className="mb-8 p-5 rounded-2xl bg-blue-50 text-blue-800 font-semibold">
+        {t('resultScreen.resultNotice')}
+      </div>
+
+      <Button className="apple-button mt-4" onClick={onScheduleInterview}>
+        {t('resultScreen.scheduleInterviewCta')}
+      </Button>
     </motion.div>
   );
 };

--- a/src/components/assessment/renderQuestion.tsx
+++ b/src/components/assessment/renderQuestion.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import type { Question } from '@/types/question';
+import type { AnswerValue } from '@/types/assessment';
+import { Textarea } from '@/components/ui/textarea';
+
+interface RenderQuestionConfig {
+  currentAnswer: AnswerValue | undefined;
+  onOptionSelect: (optionIndex: number) => void;
+  onTextChange: (value: string) => void;
+  onTextBlur: () => void;
+  t: (key: string) => string;
+}
+
+export const renderQuestion = (
+  question: Question,
+  { currentAnswer, onOptionSelect, onTextChange, onTextBlur, t }: RenderQuestionConfig,
+): React.ReactNode => {
+  if (question.format === 'multiple_choice') {
+    if (!question.options || question.options.length === 0) {
+      return (
+        <p className="text-sm text-muted-foreground">
+          {t('assessmentScreen.noOptions')}
+        </p>
+      );
+    }
+
+    return question.options.map((option, index) => {
+      const isSelected = Number(currentAnswer) === index;
+      return (
+        <motion.div
+          key={option.id}
+          initial={{ opacity: 0, x: -20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.5, delay: index * 0.1 }}
+          whileHover={{ scale: 1.02 }}
+          whileTap={{ scale: 0.98 }}
+        >
+          <div
+            className={`relative flex items-center p-6 border-2 rounded-2xl cursor-pointer transition-all duration-300 font-medium text-lg min-h-[70px] ${
+              isSelected
+                ? 'bg-blue-100 border-blue-500 text-blue-800 shadow-lg shadow-blue-200'
+                : 'bg-white border-gray-200 hover:bg-gray-50 hover:border-gray-300 hover:shadow-md'
+            }`}
+            onClick={() => onOptionSelect(index)}
+          >
+            <span className="flex-1 text-left text-sm">{option.text}</span>
+          </div>
+        </motion.div>
+      );
+    });
+  }
+
+  return (
+    <Textarea
+      placeholder={t('assessmentScreen.typeYourAnswer')}
+      value={typeof currentAnswer === 'string' ? currentAnswer : ''}
+      onChange={(event) => onTextChange(event.target.value)}
+      onBlur={onTextBlur}
+      className="min-h-[150px] p-4 border-2 rounded-2xl focus:border-blue-500 focus:ring-blue-500 transition-all duration-300"
+    />
+  );
+};

--- a/src/contexts/AssessmentContext.tsx
+++ b/src/contexts/AssessmentContext.tsx
@@ -1,4 +1,4 @@
-﻿import { createContext, useContext, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
 import type { Role, AssessmentResult, AssessmentAttempt } from '@/types/assessment';
 
 interface AssessmentState {

--- a/src/lib/api/assessments.ts
+++ b/src/lib/api/assessments.ts
@@ -1,29 +1,19 @@
-﻿import { supabase } from '../supabaseClient';
+import { supabase } from '../supabaseClient';
 import type { Question } from '../types/question';
-import type { AssessmentAttempt } from '@/types/assessment';
+import type { Assessment, AssessmentAttempt } from '@/types/assessment';
 import {
   mapSupabaseQuestion,
-  normaliseQuestionFormat,
   type SupabaseQuestionData,
+  type SupabaseQuestionOptionData,
 } from './questionMappers';
 import type { AnswerInput, AnswerRow, AssessmentAttemptRow } from './types';
-
-interface AssessmentPayload {
-  id: string;
-  title: string;
-  description: string | null;
-  duration: number | null;
-  questions: Array<{
-    id: string;
-    text: string;
-    format: string;
-    required?: boolean;
-    options: Array<{ id: string; option_text: string; is_correct: boolean }>;
-  }>;
-}
+import { getResultForAttempt } from './results';
+import type { AssessmentResult } from '@/types/assessment';
 
 const mapAssessmentAttempt = (row: AssessmentAttemptRow): AssessmentAttempt => ({
   id: row.id,
+  assessmentId: row.assessment_id,
+  role: row.role,
   status: row.status,
   answeredCount: row.answered_count ?? 0,
   totalQuestions: row.total_questions ?? 0,
@@ -32,58 +22,84 @@ const mapAssessmentAttempt = (row: AssessmentAttemptRow): AssessmentAttempt => (
   submittedAt: row.submitted_at,
   completedAt: row.completed_at,
   lastActivityAt: row.last_activity_at,
+  cheatingCount: row.cheating_count ?? 0,
 });
 
-export const getAssessment = async (role: string) => {
+const mapQuestionRows = (
+  rows: SupabaseQuestionData[],
+  optionsByQuestion: Record<string, SupabaseQuestionOptionData[]>,
+): Question[] =>
+  rows.map((row) =>
+    mapSupabaseQuestion({
+      ...row,
+      options: optionsByQuestion[row.id] ?? [],
+    }),
+  );
+
+const fetchQuestionOptions = async (questionIds: string[]) => {
+  if (questionIds.length === 0) {
+    return {} as Record<string, SupabaseQuestionOptionData[]>;
+  }
+
   const { data, error } = await supabase
-    .from('assessments')
-    .select(
-      `
-        id,
-        title,
-        description,
-        duration,
-        questions:questions(
-          id,
-          text,
-          format,
-          required,
-          options:question_options(id, option_text, is_correct)
-        )
-      `,
-    )
-    .eq('target_role', role)
-    .single();
+    .from('question_options')
+    .select('id, question_id, option_text, is_correct')
+    .in('question_id', questionIds);
 
   if (error) {
-    console.error(`Failed to load assessment for role ${role}:`, error);
+    console.error('Failed to load question options:', error);
+    throw new Error('Khong the tai lua chon cau hoi.');
+  }
+
+  const rows = (data as SupabaseQuestionOptionData[] | null) ?? [];
+  return rows.reduce<Record<string, SupabaseQuestionOptionData[]>>((acc, option) => {
+    const questionId = option.question_id ?? '';
+    if (!acc[questionId]) {
+      acc[questionId] = [];
+    }
+    acc[questionId].push(option);
+    return acc;
+  }, {});
+};
+
+export const getAssessment = async (role: string): Promise<Assessment | null> => {
+  const { data: assessmentRow, error: assessmentError } = await supabase
+    .from('assessments')
+    .select('id, title, description, duration')
+    .eq('target_role', role)
+    .maybeSingle();
+
+  if (assessmentError) {
+    console.error(`Failed to load assessment for role ${role}:`, assessmentError);
     throw new Error('Khong the tai bai danh gia.');
   }
 
-  if (!data) {
+  if (!assessmentRow) {
     return null;
   }
 
-  const payload = data as AssessmentPayload;
+  const { data: questionRows, error: questionsError } = await supabase
+    .from('questions')
+    .select('id, text, type, format, required, assessment_id, created_at')
+    .eq('assessment_id', assessmentRow.id)
+    .order('created_at', { ascending: true });
+
+  if (questionsError) {
+    console.error('Failed to load questions for assessment:', questionsError);
+    throw new Error('Khong the tai danh sach cau hoi.');
+  }
+
+  const rawQuestions = (questionRows as SupabaseQuestionData[] | null) ?? [];
+  const optionsByQuestion = await fetchQuestionOptions(rawQuestions.map((question) => question.id));
+  const questions = mapQuestionRows(rawQuestions, optionsByQuestion);
 
   return {
-    ...payload,
-    questions: payload.questions.map((question) => ({
-      id: question.id,
-      text: question.text,
-      type: 'General',
-      format: normaliseQuestionFormat(question.format),
-      required: question.required ?? true,
-      points: 0,
-      options: question.options.map((option) => ({
-        id: option.id,
-        text: option.option_text,
-        optionText: option.option_text,
-        isCorrect: option.is_correct,
-      })),
-      correctAnswer: question.options.find((option) => option.is_correct)?.id,
-    })),
-  };
+    id: assessmentRow.id,
+    title: assessmentRow.title,
+    description: assessmentRow.description,
+    duration: assessmentRow.duration ?? 0,
+    questions,
+  } satisfies Assessment;
 };
 
 export const getQuestionsByIds = async (questionIds: string[]): Promise<Question[]> => {
@@ -93,18 +109,7 @@ export const getQuestionsByIds = async (questionIds: string[]): Promise<Question
 
   const { data, error } = await supabase
     .from('questions')
-    .select(
-      `
-        id,
-        text,
-        type,
-        format,
-        required,
-        assessment_id,
-        created_at,
-        options:question_options(id, option_text, is_correct)
-      `,
-    )
+    .select('id, text, type, format, required, assessment_id, created_at')
     .in('id', questionIds);
 
   if (error) {
@@ -112,11 +117,14 @@ export const getQuestionsByIds = async (questionIds: string[]): Promise<Question
     throw new Error('Khong the tai danh sach cau hoi.');
   }
 
-  return ((data as SupabaseQuestionData[] | null) ?? []).map(mapSupabaseQuestion);
+  const rows = (data as SupabaseQuestionData[] | null) ?? [];
+  const optionsByQuestion = await fetchQuestionOptions(rows.map((question) => question.id));
+  return mapQuestionRows(rows, optionsByQuestion);
 };
 
 export const upsertAnswer = async (payload: AnswerInput): Promise<AnswerRow> => {
   const base = {
+    assessment_attempt_id: payload.attemptId ?? null,
     result_id: payload.resultId ?? null,
     question_id: payload.questionId,
     user_answer_text: payload.userAnswerText ?? null,
@@ -243,6 +251,7 @@ export const startAssessmentAttempt = async (payload: {
       status: 'in_progress',
       started_at: nowIso,
       last_activity_at: nowIso,
+      cheating_count: 0,
     })
     .select()
     .single();
@@ -255,7 +264,10 @@ export const startAssessmentAttempt = async (payload: {
   return mapAssessmentAttempt(data as AssessmentAttemptRow);
 };
 
-export const submitAssessmentAttempt = async (attemptId: string): Promise<AssessmentAttempt> => {
+export const submitAssessmentAttempt = async (
+  attemptId: string,
+  cheatingCount = 0,
+): Promise<AssessmentAttempt> => {
   const nowIso = new Date().toISOString();
   const { data, error } = await supabase
     .from('assessment_attempts')
@@ -263,6 +275,7 @@ export const submitAssessmentAttempt = async (attemptId: string): Promise<Assess
       status: 'awaiting_ai',
       submitted_at: nowIso,
       last_activity_at: nowIso,
+      cheating_count: cheatingCount,
     })
     .eq('id', attemptId)
     .select()
@@ -274,4 +287,79 @@ export const submitAssessmentAttempt = async (attemptId: string): Promise<Assess
   }
 
   return mapAssessmentAttempt(data as AssessmentAttemptRow);
+};
+
+export const getAnswersForAttempt = async (attemptId: string): Promise<AnswerRow[]> => {
+  const { data, error } = await supabase
+    .from('answers')
+    .select('id, assessment_attempt_id, result_id, question_id, user_answer_text, selected_option_id, created_at')
+    .eq('assessment_attempt_id', attemptId);
+
+  if (error) {
+    console.error('Failed to load answers for attempt:', error);
+    throw new Error('Khong the tai cau tra loi.');
+  }
+
+  return (data as AnswerRow[] | null) ?? [];
+};
+
+export interface AttemptAnswerDetail {
+  answer: AnswerRow;
+  question: Question | null;
+  resolvedAnswer: string;
+}
+
+export const getAttemptAnswerDetails = async (
+  attemptId: string,
+): Promise<{ details: AttemptAnswerDetail[]; completedCount: number }> => {
+  const answers = await getAnswersForAttempt(attemptId);
+  const questionIds = Array.from(new Set(answers.map((answer) => answer.question_id)));
+  const questions = await getQuestionsByIds(questionIds);
+  const questionMap = new Map(questions.map((question) => [question.id, question]));
+
+  const details = answers.map<AttemptAnswerDetail>((answer) => {
+    const question = questionMap.get(answer.question_id) ?? null;
+    let resolvedAnswer = answer.user_answer_text ?? '';
+
+    if (!resolvedAnswer && answer.selected_option_id && question?.options) {
+      const selected = question.options.find((option) => option.id === answer.selected_option_id);
+      resolvedAnswer = selected?.text ?? '';
+    }
+
+    return {
+      answer,
+      question,
+      resolvedAnswer: resolvedAnswer?.trim() ?? '',
+    };
+  });
+
+  const completedCount = details.filter((detail) => detail.resolvedAnswer.length > 0).length;
+
+  return { details, completedCount };
+};
+
+export const getCandidateProgress = async (
+  profileId: string,
+): Promise<{ attempt: AssessmentAttempt | null; result: AssessmentResult | null }> => {
+  const { data, error } = await supabase
+    .from('assessment_attempts')
+    .select('*')
+    .eq('profile_id', profileId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Failed to load candidate progress:', error);
+    throw new Error('Khong the tai tien trinh ung vien.');
+  }
+
+  if (!data) {
+    return { attempt: null, result: null };
+  }
+
+  const attempt = mapAssessmentAttempt(data as AssessmentAttemptRow);
+  const result = await getResultForAttempt(attempt.id);
+
+  return { attempt, result };
 };

--- a/src/lib/api/gemini.ts
+++ b/src/lib/api/gemini.ts
@@ -1,0 +1,169 @@
+interface GeminiAnswerPayload {
+  questionId: string;
+  questionText: string;
+  format: string;
+  answer: string;
+}
+
+interface GeminiAnalysisInput {
+  answers: GeminiAnswerPayload[];
+  cheatingCount: number;
+  completedCount: number;
+  role?: string | null;
+  assessmentTitle?: string | null;
+}
+
+export interface GeminiAnalysisResult {
+  overallScore: number | null;
+  strengths: string[];
+  weaknesses: string[];
+  summary: string | null;
+  skillScores?: Record<string, number>;
+  aiSummary?: string | null;
+}
+
+const MODEL_NAME = 'gemini-2.5-flash';
+
+const toNumberOrNull = (value: unknown): number | null => {
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  return null;
+};
+
+const toStringArray = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item)).filter((item) => item.trim().length > 0);
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed.map((item) => String(item)).filter((item) => item.trim().length > 0);
+      }
+    } catch (error) {
+      return [trimmed];
+    }
+  }
+
+  return [];
+};
+
+const toSkillScores = (value: unknown): Record<string, number> | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, score]) => [key, Number(score)]).filter(([, score]) => !Number.isNaN(score)),
+    );
+  }
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return Object.fromEntries(
+          Object.entries(parsed).map(([key, score]) => [key, Number(score)]).filter(([, score]) => !Number.isNaN(score)),
+        );
+      }
+    } catch (error) {
+      console.warn('Failed to parse Gemini skill scores JSON:', error);
+    }
+  }
+
+  return undefined;
+};
+
+export const analyzeWithGemini = async (
+  input: GeminiAnalysisInput,
+): Promise<GeminiAnalysisResult> => {
+  const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('Gemini API key is not configured.');
+  }
+
+  const prompt = [
+    'You are an HR assessment assistant. Analyse the candidate responses and summarise insights for the recruiter.',
+    `Role: ${input.role ?? 'Unknown'}`,
+    `Assessment: ${input.assessmentTitle ?? 'N/A'}`,
+    `Total answered questions: ${input.completedCount}.`,
+    `Detected cheating incidents (tab switch): ${input.cheatingCount}.`,
+    'Each answer is provided below. Focus on professional tone and respond in Vietnamese.',
+    'Return ONLY a valid JSON object with the following structure:',
+    '{"overall_score": number (0-100), "skill_scores": {"skill": number}, "strengths": [string], "weaknesses": [string], "summary": string}',
+    'Do not include any additional commentary outside of the JSON response.',
+    'Candidate responses:',
+    ...input.answers.map(
+      (item, index) =>
+        `${index + 1}. [${item.format}] ${item.questionText}\nCandidate answer: ${item.answer || 'Chưa có câu trả lời.'}`,
+    ),
+  ].join('\n\n');
+
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${MODEL_NAME}:generateContent?key=${apiKey}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: prompt }],
+          },
+        ],
+        generationConfig: {
+          temperature: 0.4,
+          responseMimeType: 'application/json',
+        },
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    console.error('Gemini API error:', errorBody);
+    throw new Error('Khong the phan tich ket qua voi Gemini.');
+  }
+
+  const json = await response.json();
+  const candidateText: string | undefined = json?.candidates?.[0]?.content?.parts?.[0]?.text;
+
+  if (!candidateText) {
+    throw new Error('Khong the doc phan hoi tu Gemini.');
+  }
+
+  let parsed: Record<string, unknown>;
+
+  try {
+    parsed = JSON.parse(candidateText);
+  } catch (error) {
+    console.error('Failed to parse Gemini response:', error, candidateText);
+    throw new Error('Gemini tra ve du lieu khong hop le.');
+  }
+
+  return {
+    overallScore: toNumberOrNull(parsed.overall_score),
+    strengths: toStringArray(parsed.strengths),
+    weaknesses: toStringArray(parsed.weaknesses),
+    summary: typeof parsed.summary === 'string' ? parsed.summary : null,
+    skillScores: toSkillScores(parsed.skill_scores),
+    aiSummary: typeof parsed.ai_summary === 'string' ? parsed.ai_summary : undefined,
+  } satisfies GeminiAnalysisResult;
+};

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,4 +1,4 @@
-﻿export * from './types';
+export * from './types';
 
 export { getLandingPageData, updateLandingPageData } from './landingPage';
 export { getRoles, createRole, deleteRole } from './roles';
@@ -12,4 +12,8 @@ export {
   ensureProfile,
   startAssessmentAttempt,
   submitAssessmentAttempt,
+  getAnswersForAttempt,
+  getAttemptAnswerDetails,
+  getCandidateProgress,
 } from './assessments';
+export { saveAssessmentResultAnalysis, getResultForAttempt } from './results';

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -16,4 +16,4 @@ export {
   getAttemptAnswerDetails,
   getCandidateProgress,
 } from './assessments';
-export { saveAssessmentResultAnalysis, getResultForAttempt } from './results';
+export { saveAssessmentResultAnalysis, getResultForCandidate } from './results';

--- a/src/lib/api/questionMappers.ts
+++ b/src/lib/api/questionMappers.ts
@@ -1,23 +1,24 @@
-﻿import type { Question, QuestionOption } from '../types/question';
+import type { Question, QuestionOption } from '../types/question';
 
 export interface SupabaseQuestionOptionData {
   id: string;
   option_text: string;
   is_correct: boolean;
+  question_id?: string | null;
 }
 
 export interface SupabaseQuestionData {
   id: string;
   text: string;
   type?: string;
-  format: 'text' | 'multiple_choice' | 'multiple-choice';
+  format?: string | null;
   required?: boolean;
   assessment_id?: string | null;
   created_at?: string;
-  options: SupabaseQuestionOptionData[];
+  options?: SupabaseQuestionOptionData[];
 }
 
-export const MULTIPLE_CHOICE_FORMATS = new Set(['multiple_choice', 'multiple-choice']);
+export const MULTIPLE_CHOICE_FORMATS = new Set(['multiple_choice', 'multiple-choice', 'single']);
 
 export const normaliseQuestionFormat = (format?: string | null): Question['format'] => {
   if (!format) {
@@ -25,6 +26,10 @@ export const normaliseQuestionFormat = (format?: string | null): Question['forma
   }
 
   if (format === 'multiple-choice') {
+    return 'multiple_choice';
+  }
+
+  if (format === 'single') {
     return 'multiple_choice';
   }
 

--- a/src/lib/api/results.ts
+++ b/src/lib/api/results.ts
@@ -1,5 +1,5 @@
 import { supabase } from '../supabaseClient';
-import type { AssessmentResult } from '@/types/assessment';
+import type { AssessmentAttempt, AssessmentResult } from '@/types/assessment';
 import type { ResultRow } from './types';
 
 const penaltyPerViolation = 10;
@@ -58,6 +58,23 @@ const toSkillScores = (value: unknown): Record<string, number> | undefined => {
   return undefined;
 };
 
+const toOptionalString = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (value && typeof value === 'object') {
+    const summary = (value as Record<string, unknown>).summary;
+    if (typeof summary === 'string') {
+      const trimmed = summary.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    }
+  }
+
+  return null;
+};
+
 const calculateAdjustedScore = (score: number | null, cheatingCount: number | null): number => {
   const baseScore = typeof score === 'number' && !Number.isNaN(score) ? score : 0;
   const violations = Math.max(0, cheatingCount ?? 0);
@@ -65,31 +82,33 @@ const calculateAdjustedScore = (score: number | null, cheatingCount: number | nu
   return Math.max(0, Math.round(baseScore - penalty));
 };
 
-const mapResultRow = (row: ResultRow): AssessmentResult => {
-  const strengths = toStringArray(row.strengths ?? []);
-  const weaknesses = toStringArray(row.weaknesses ?? []);
-  const summary = row.summary ?? row.ai_summary ?? null;
-  const cheatingCount = row.cheating_count ?? 0;
+const mapResultRow = (
+  row: ResultRow,
+  metadata: { attemptId: string; completedCount: number; cheatingCount: number },
+): AssessmentResult => {
+  const strengths = toStringArray(row.strengths);
+  const weaknesses = toStringArray(row.weaknesses);
+  const summary = toOptionalString(row.summary);
+  const aiSummary = toOptionalString(row.ai_summary) ?? summary;
+  const cheatingCount = metadata.cheatingCount ?? 0;
   const overallScore = row.overall_score;
 
   return {
-    attemptId: row.assessment_attempt_id,
+    attemptId: metadata.attemptId,
     overallScore,
     adjustedScore: calculateAdjustedScore(overallScore, cheatingCount),
     strengths,
     weaknesses,
-    summary,
-    aiSummary: row.ai_summary ?? summary,
+    summary: summary ?? aiSummary,
+    aiSummary,
     skillScores: toSkillScores(row.skill_scores ?? undefined),
-    completedCount: row.total_answered ?? 0,
+    completedCount: metadata.completedCount,
     cheatingCount,
   } satisfies AssessmentResult;
 };
 
 interface ResultPayload {
-  attemptId: string;
-  assessmentId: string | null;
-  profileId: string | null;
+  attempt: AssessmentAttempt;
   overallScore: number | null;
   strengths: string[];
   weaknesses: string[];
@@ -103,46 +122,147 @@ interface ResultPayload {
 export const saveAssessmentResultAnalysis = async (
   payload: ResultPayload,
 ): Promise<AssessmentResult> => {
-  const { data, error } = await supabase
-    .from('results')
-    .upsert(
-      {
-        assessment_attempt_id: payload.attemptId,
-        assessment_id: payload.assessmentId,
-        profile_id: payload.profileId,
-        overall_score: payload.overallScore,
-        strengths: payload.strengths,
-        weaknesses: payload.weaknesses,
-        summary: payload.summary,
-        ai_summary: payload.aiSummary ?? payload.summary,
-        skill_scores: payload.skillScores ?? null,
-        total_answered: payload.completedCount,
-        cheating_count: payload.cheatingCount,
-      },
-      { onConflict: 'assessment_attempt_id' },
-    )
-    .select()
-    .single();
+  const { attempt } = payload;
+  const nowIso = new Date().toISOString();
 
-  if (error) {
-    console.error('Failed to save assessment result:', error);
+  if (!attempt.profileId || !attempt.assessmentId) {
+    throw new Error('Missing attempt context to save assessment result.');
+  }
+
+  const baseResult = {
+    user_id: attempt.profileId,
+    assessment_id: attempt.assessmentId,
+    overall_score: payload.overallScore,
+    strengths: payload.strengths,
+    weaknesses: payload.weaknesses,
+    summary: payload.summary,
+    ai_summary: payload.aiSummary ?? payload.summary,
+    skill_scores: payload.skillScores ?? null,
+    analysis_completed_at: nowIso,
+    cheating_summary: {
+      cheating_count: payload.cheatingCount,
+      completed_count: payload.completedCount,
+      adjusted_score: calculateAdjustedScore(payload.overallScore, payload.cheatingCount),
+    },
+  } satisfies Partial<ResultRow> & Record<string, unknown>;
+
+  const { data: existingResult, error: fetchError } = await supabase
+    .from('results')
+    .select('id')
+    .eq('user_id', attempt.profileId)
+    .eq('assessment_id', attempt.assessmentId)
+    .limit(1)
+    .maybeSingle();
+
+  if (fetchError) {
+    console.error('Failed to check existing assessment result:', fetchError);
     throw new Error('Khong the luu ket qua danh gia.');
   }
 
-  return mapResultRow(data as ResultRow);
+  let savedRow: ResultRow | null = null;
+
+  if (existingResult?.id) {
+    const { data, error } = await supabase
+      .from('results')
+      .update(baseResult)
+      .eq('id', existingResult.id)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Failed to update assessment result:', error);
+      throw new Error('Khong the luu ket qua danh gia.');
+    }
+
+    savedRow = data as ResultRow;
+  } else {
+    const { data, error } = await supabase
+      .from('results')
+      .insert(baseResult)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Failed to create assessment result:', error);
+      throw new Error('Khong the luu ket qua danh gia.');
+    }
+
+    savedRow = data as ResultRow;
+  }
+
+  const progressPercent =
+    attempt.totalQuestions > 0
+      ? Math.min(100, Math.round((payload.completedCount / attempt.totalQuestions) * 100))
+      : attempt.progressPercent;
+
+  const attemptUpdate = {
+    status: 'completed',
+    answered_count: payload.completedCount,
+    progress_percent: progressPercent,
+    completed_at: nowIso,
+    last_activity_at: nowIso,
+    ai_status: 'completed',
+    cheating_count: payload.cheatingCount,
+    ai_summary: {
+      overall_score: payload.overallScore,
+      adjusted_score: calculateAdjustedScore(payload.overallScore, payload.cheatingCount),
+      strengths: payload.strengths,
+      weaknesses: payload.weaknesses,
+      summary: payload.summary,
+      skill_scores: payload.skillScores ?? null,
+    },
+  } satisfies Record<string, unknown>;
+
+  const { error: attemptError } = await supabase
+    .from('assessment_attempts')
+    .update(attemptUpdate)
+    .eq('id', attempt.id);
+
+  if (attemptError) {
+    console.error('Failed to update assessment attempt after analysis:', attemptError);
+  }
+
+  if (!savedRow) {
+    throw new Error('Khong the luu ket qua danh gia.');
+  }
+
+  return mapResultRow(savedRow, {
+    attemptId: attempt.id,
+    completedCount: payload.completedCount,
+    cheatingCount: payload.cheatingCount,
+  });
 };
 
-export const getResultForAttempt = async (
-  attemptId: string,
+interface ResultQueryInput {
+  attemptId: string;
+  profileId: string;
+  assessmentId: string;
+  completedCount: number;
+  cheatingCount: number;
+}
+
+export const getResultForCandidate = async (
+  input: ResultQueryInput,
 ): Promise<AssessmentResult | null> => {
+  const { profileId, assessmentId } = input;
+
+  if (!profileId || !assessmentId) {
+    return null;
+  }
+
   const { data, error } = await supabase
     .from('results')
-    .select('*')
-    .eq('assessment_attempt_id', attemptId)
+    .select(
+      'id, user_id, assessment_id, completed_at, overall_score, strengths, weaknesses, summary, ai_summary, skill_scores, analysis_completed_at, cheating_summary',
+    )
+    .eq('user_id', profileId)
+    .eq('assessment_id', assessmentId)
+    .order('analysis_completed_at', { ascending: false })
+    .limit(1)
     .maybeSingle();
 
   if (error) {
-    console.error('Failed to load result for attempt:', error);
+    console.error('Failed to load assessment result:', error);
     throw new Error('Khong the tai ket qua danh gia.');
   }
 
@@ -150,5 +270,28 @@ export const getResultForAttempt = async (
     return null;
   }
 
-  return mapResultRow(data as ResultRow);
+  const row = data as ResultRow;
+
+  let cheatingCount = input.cheatingCount;
+  let completedCount = input.completedCount;
+
+  if (row.cheating_summary && typeof row.cheating_summary === 'object') {
+    const summary = row.cheating_summary as Record<string, unknown>;
+    const cheatingFromSummary = Number(summary.cheating_count);
+    const completedFromSummary = Number(summary.completed_count);
+
+    if (!Number.isNaN(cheatingFromSummary)) {
+      cheatingCount = cheatingFromSummary;
+    }
+
+    if (!Number.isNaN(completedFromSummary) && completedFromSummary > 0) {
+      completedCount = completedFromSummary;
+    }
+  }
+
+  return mapResultRow(row, {
+    attemptId: input.attemptId,
+    completedCount,
+    cheatingCount,
+  });
 };

--- a/src/lib/api/results.ts
+++ b/src/lib/api/results.ts
@@ -1,0 +1,154 @@
+import { supabase } from '../supabaseClient';
+import type { AssessmentResult } from '@/types/assessment';
+import type { ResultRow } from './types';
+
+const penaltyPerViolation = 10;
+
+const toStringArray = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item)).filter((item) => item.trim().length > 0);
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed.map((item) => String(item)).filter((item) => item.trim().length > 0);
+      }
+    } catch (error) {
+      // fall through
+    }
+
+    return [trimmed];
+  }
+
+  return [];
+};
+
+const toSkillScores = (value: unknown): Record<string, number> | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return Object.fromEntries(
+          Object.entries(parsed).map(([key, score]) => [key, Number(score)]).filter(([, score]) => !Number.isNaN(score)),
+        );
+      }
+    } catch (error) {
+      console.warn('Failed to parse skill scores JSON:', error);
+      return undefined;
+    }
+  }
+
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, score]) => [key, Number(score)]).filter(([, score]) => !Number.isNaN(score)),
+    );
+  }
+
+  return undefined;
+};
+
+const calculateAdjustedScore = (score: number | null, cheatingCount: number | null): number => {
+  const baseScore = typeof score === 'number' && !Number.isNaN(score) ? score : 0;
+  const violations = Math.max(0, cheatingCount ?? 0);
+  const penalty = violations * penaltyPerViolation;
+  return Math.max(0, Math.round(baseScore - penalty));
+};
+
+const mapResultRow = (row: ResultRow): AssessmentResult => {
+  const strengths = toStringArray(row.strengths ?? []);
+  const weaknesses = toStringArray(row.weaknesses ?? []);
+  const summary = row.summary ?? row.ai_summary ?? null;
+  const cheatingCount = row.cheating_count ?? 0;
+  const overallScore = row.overall_score;
+
+  return {
+    attemptId: row.assessment_attempt_id,
+    overallScore,
+    adjustedScore: calculateAdjustedScore(overallScore, cheatingCount),
+    strengths,
+    weaknesses,
+    summary,
+    aiSummary: row.ai_summary ?? summary,
+    skillScores: toSkillScores(row.skill_scores ?? undefined),
+    completedCount: row.total_answered ?? 0,
+    cheatingCount,
+  } satisfies AssessmentResult;
+};
+
+interface ResultPayload {
+  attemptId: string;
+  assessmentId: string | null;
+  profileId: string | null;
+  overallScore: number | null;
+  strengths: string[];
+  weaknesses: string[];
+  summary: string | null;
+  aiSummary?: string | null;
+  skillScores?: Record<string, number>;
+  completedCount: number;
+  cheatingCount: number;
+}
+
+export const saveAssessmentResultAnalysis = async (
+  payload: ResultPayload,
+): Promise<AssessmentResult> => {
+  const { data, error } = await supabase
+    .from('results')
+    .upsert(
+      {
+        assessment_attempt_id: payload.attemptId,
+        assessment_id: payload.assessmentId,
+        profile_id: payload.profileId,
+        overall_score: payload.overallScore,
+        strengths: payload.strengths,
+        weaknesses: payload.weaknesses,
+        summary: payload.summary,
+        ai_summary: payload.aiSummary ?? payload.summary,
+        skill_scores: payload.skillScores ?? null,
+        total_answered: payload.completedCount,
+        cheating_count: payload.cheatingCount,
+      },
+      { onConflict: 'assessment_attempt_id' },
+    )
+    .select()
+    .single();
+
+  if (error) {
+    console.error('Failed to save assessment result:', error);
+    throw new Error('Khong the luu ket qua danh gia.');
+  }
+
+  return mapResultRow(data as ResultRow);
+};
+
+export const getResultForAttempt = async (
+  attemptId: string,
+): Promise<AssessmentResult | null> => {
+  const { data, error } = await supabase
+    .from('results')
+    .select('*')
+    .eq('assessment_attempt_id', attemptId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Failed to load result for attempt:', error);
+    throw new Error('Khong the tai ket qua danh gia.');
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return mapResultRow(data as ResultRow);
+};

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -26,7 +26,7 @@ export interface CandidateInfo {
 
 export interface AnswerRow {
   id: string;
-  assessment_attempt_id: string | null;
+  attempt_id: string | null;
   result_id: string | null;
   question_id: string;
   user_answer_text: string | null;
@@ -61,19 +61,17 @@ export interface AssessmentAttemptRow {
 
 export interface ResultRow {
   id: string;
-  assessment_attempt_id: string;
+  user_id: string | null;
   assessment_id: string | null;
-  profile_id: string | null;
+  completed_at: string | null;
   overall_score: number | null;
-  strengths: string[] | null;
-  weaknesses: string[] | null;
+  strengths: unknown;
+  weaknesses: unknown;
   summary: string | null;
-  ai_summary: string | null;
+  ai_summary: unknown;
   skill_scores: Record<string, number> | null;
-  total_answered: number | null;
-  cheating_count: number | null;
-  created_at?: string | null;
-  updated_at?: string | null;
+  analysis_completed_at: string | null;
+  cheating_summary: unknown;
 }
 
 export type QuestionsByRole = Record<string, Question[]>;

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -1,4 +1,4 @@
-﻿import type { Question } from '../types/question';
+import type { Question } from '../types/question';
 import type { AssessmentAttempt } from '@/types/assessment';
 
 export interface ProfileUpdates {
@@ -26,6 +26,7 @@ export interface CandidateInfo {
 
 export interface AnswerRow {
   id: string;
+  assessment_attempt_id: string | null;
   result_id: string | null;
   question_id: string;
   user_answer_text: string | null;
@@ -55,6 +56,24 @@ export interface AssessmentAttemptRow {
   submitted_at: string | null;
   completed_at: string | null;
   last_activity_at: string | null;
+  cheating_count: number | null;
+}
+
+export interface ResultRow {
+  id: string;
+  assessment_attempt_id: string;
+  assessment_id: string | null;
+  profile_id: string | null;
+  overall_score: number | null;
+  strengths: string[] | null;
+  weaknesses: string[] | null;
+  summary: string | null;
+  ai_summary: string | null;
+  skill_scores: Record<string, number> | null;
+  total_answered: number | null;
+  cheating_count: number | null;
+  created_at?: string | null;
+  updated_at?: string | null;
 }
 
 export type QuestionsByRole = Record<string, Question[]>;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -85,7 +85,8 @@
     "noAssessment": "This position currently has no assessment.",
     "typeYourAnswer": "Type your answer here...",
     "selectYourAnswer": "Select your answer",
-    "errorLoading": "Error loading assessment. Please try again later."
+    "errorLoading": "Error loading assessment. Please try again later.",
+    "noOptions": "No answer options available."
   },
   "preAssessmentScreen": {
     "title": "Are you ready for the test?",
@@ -100,13 +101,21 @@
   "resultScreen": {
     "title": "Thank you for completing!",
     "subtitle": "Here is a quick summary of your strengths.",
-    "strengthsTitle": "Top 3 standout strengths:",
+    "strengthsTitle": "Key strengths",
+    "weaknessesTitle": "Growth opportunities",
+    "noStrengths": "No specific strengths recorded yet.",
+    "noWeaknesses": "No major gaps detected.",
     "nextStepsTitle": "Next Steps",
-    "successText": "Your results are impressive! As a next step, we invite you to schedule a direct interview with the team.",
-    "successCta": "Schedule Interview",
-    "tryoutText": "You have shown great potential. To understand your practical skills better, we invite you to join our Tryout/Volunteer Program.",
-    "tryoutCta": "Continue to Tryout Program",
-    "thankyou": "Thank you for completing!",
+    "overallScore": "Overall score",
+    "adjustedScore": "Adjusted score",
+    "adjustedScoreNotice": "Initial score {base} adjusted to {adjusted} after reviewing the violations.",
+    "cheatingCount": "Cheating incidents",
+    "cheatingWarning": "The system detected {count} focus changes during the test. The displayed score has been adjusted accordingly.",
+    "completedQuestions": "Questions completed",
+    "skillScoresTitle": "Skill breakdown",
+    "analysisSummaryTitle": "AI summary",
+    "resultNotice": "Results have been sent to HR. Please check your email or revisit this page for updates.",
+    "scheduleInterviewCta": "Schedule interview",
     "missingTitle": "We could not find your latest results yet.",
     "missingDescription": "Please complete the assessment first or refresh this page once your results are ready.",
     "backToSelection": "Back to role selection"

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -85,7 +85,8 @@
     "noAssessment": "Vị trí này hiện tại không có bài đánh giá.",
     "typeYourAnswer": "Nhập câu trả lời của bạn tại đây...",
     "selectYourAnswer": "Chọn câu trả lời của bạn",
-    "errorLoading": "Lỗi tải bài đánh giá. Vui lòng thử lại sau."
+    "errorLoading": "Lỗi tải bài đánh giá. Vui lòng thử lại sau.",
+    "noOptions": "Không có đáp án."
   },
   "preAssessmentScreen": {
     "title": "Bạn đã sẵn sàng cho bài kiểm tra chưa?",
@@ -100,13 +101,21 @@
   "resultScreen": {
     "title": "Cảm ơn bạn đã hoàn thành!",
     "subtitle": "Đây là tóm tắt nhanh về điểm mạnh của bạn.",
-    "strengthsTitle": "Top 3 điểm mạnh nổi bật:",
+    "strengthsTitle": "Điểm mạnh nổi bật",
+    "weaknessesTitle": "Điểm cần cải thiện",
+    "noStrengths": "Chưa ghi nhận điểm mạnh nào.",
+    "noWeaknesses": "Không có điểm yếu đáng kể được phát hiện.",
     "nextStepsTitle": "Bước Tiếp Theo",
-    "successText": "Kết quả của bạn thật ấn tượng! Bước tiếp theo, chúng tôi mời bạn lên lịch phỏng vấn trực tiếp với đội ngũ.",
-    "successCta": "Lên Lịch Phỏng Vấn",
-    "tryoutText": "Bạn đã thể hiện tiềm năng rất lớn. Để hiểu rõ hơn về kỹ năng thực tế của bạn, chúng tôi mời bạn tham gia Chương Trình Thử Việc/Tình Nguyện.",
-    "tryoutCta": "Tiếp Tục Đến Chương Trình Thử Việc",
-    "thankyou": "Cảm ơn bạn đã hoàn thành!",
+    "overallScore": "Điểm tổng quan",
+    "adjustedScore": "Điểm sau điều chỉnh",
+    "adjustedScoreNotice": "Điểm ban đầu {base} đã được điều chỉnh còn {adjusted} sau khi xem xét các vi phạm.",
+    "cheatingCount": "Số lần vi phạm",
+    "cheatingWarning": "Hệ thống phát hiện {count} lần rời khỏi bài làm. Điểm đã được điều chỉnh để phản ánh mức độ tin cậy của bài làm.",
+    "completedQuestions": "Số câu hoàn thành",
+    "skillScoresTitle": "Điểm năng lực theo kỹ năng",
+    "analysisSummaryTitle": "Tổng kết từ AI",
+    "resultNotice": "Kết quả đã được gửi về HR, vui lòng theo dõi email hoặc quay lại trang web để nhận kết quả.",
+    "scheduleInterviewCta": "Lên lịch phỏng vấn",
     "missingTitle": "Chúng tôi chưa thể tìm thấy kết quả mới nhất của bạn.",
     "missingDescription": "Vui lòng hoàn thành bài đánh giá trước hoặc làm mới trang này khi kết quả của bạn đã sẵn sàng.",
     "backToSelection": "Quay lại lựa chọn vai trò"

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -1,20 +1,6 @@
 // src/types/assessment.ts
 
-export interface Question {
-  id: string;
-  text: string;
-  type: string;
-  format: 'text' | 'multiple_choice';
-  required: boolean;
-  points: number;
-  options?: Option[];
-  correctAnswer?: string;
-}
-
-export interface Option {
-  id: string;
-  text: string;
-}
+import type { Question } from './question';
 
 export type AnswerValue = string | number;
 
@@ -23,12 +9,9 @@ export type UserAnswers = Record<number, AnswerValue>;
 export interface Assessment {
   id: string;
   title: string;
-  description: string;
+  description: string | null;
   duration: number;
-  questions: {
-    question_id: string;
-    order: number;
-  }[];
+  questions: Question[];
 }
 
 export interface Role {
@@ -37,14 +20,22 @@ export interface Role {
 }
 
 export interface AssessmentResult {
-  score: number;
+  attemptId: string;
+  overallScore: number | null;
+  adjustedScore: number;
   strengths: string[];
+  weaknesses: string[];
+  summary: string | null;
+  aiSummary: string | null;
+  skillScores?: Record<string, number>;
+  completedCount: number;
+  cheatingCount: number;
 }
-
-
 
 export interface AssessmentAttempt {
   id: string;
+  assessmentId?: string | null;
+  role?: string | null;
   status: string;
   answeredCount: number;
   totalQuestions: number;
@@ -53,4 +44,5 @@ export interface AssessmentAttempt {
   submittedAt?: string | null;
   completedAt?: string | null;
   lastActivityAt?: string | null;
+  cheatingCount: number;
 }

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -34,8 +34,9 @@ export interface AssessmentResult {
 
 export interface AssessmentAttempt {
   id: string;
-  assessmentId?: string | null;
-  role?: string | null;
+  assessmentId: string;
+  profileId: string;
+  role: string;
   status: string;
   answeredCount: number;
   totalQuestions: number;

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -13,6 +13,7 @@ export type QuestionType =
 
 export const QUESTION_FORMATS = [
   'text',
+  'essay',
   'multiple_choice',
   'single',
 ] as const;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,9 +18,10 @@ export default {
 			}
 		},
 		extend: {
-			fontFamily: {
-				'inter': ['Inter', '-apple-system', 'BlinkMacSystemFont', 'sans-serif'],
-			},
+                        fontFamily: {
+                                sans: ['Inter', 'Roboto', 'Noto Sans', 'sans-serif'],
+                                inter: ['Inter', '-apple-system', 'BlinkMacSystemFont', 'sans-serif'],
+                        },
 			backgroundImage: {
 				'gradient-primary': 'var(--gradient-primary)',
 				'gradient-subtle': 'var(--gradient-subtle)',


### PR DESCRIPTION
## Summary
- refactor assessment fetching to load questions and options separately, persist attempt metadata, and expose candidate progress helpers
- add Gemini-based result analysis with Supabase storage and render richer result details including cheating adjustments
- update routing and assessment UI to restore persisted answers, handle tab violations, and normalize Vietnamese-ready fonts and strings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d68ed1b0ac832cb9eedd7d5205e280