### PR TITLE
Stabilize assessment context setters and sync Supabase progress

### DIFF
--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -9,11 +9,31 @@ import ResultScreen from './ResultScreen';
 import TryoutScreen from './TryoutScreen';
 import NotFound from '../pages/NotFound';
 import PreAssessmentScreen from './PreAssessmentScreen';
-import type { AssessmentResult } from '@/types/assessment';
+import type { AssessmentResult, AssessmentAttempt } from '@/types/assessment';
 import { useAuth } from '@/contexts/AuthContext';
 import { useAssessment } from '@/contexts/AssessmentContext';
 import { useLanguage } from '@/hooks/useLanguage';
 import ErrorPage from '../pages/ErrorPage';
+import { supabase } from '@/lib/supabaseClient';
+import type { AssessmentAttemptRow } from '@/lib/api/types';
+
+type SupabaseAttemptWithResult = AssessmentAttemptRow & {
+  role: string | null;
+  result?:
+    | null
+    | {
+        id?: string;
+        total_score?: number | null;
+        score?: number | null;
+        strengths?: unknown;
+      }
+    | Array<{
+        id?: string;
+        total_score?: number | null;
+        score?: number | null;
+        strengths?: unknown;
+      }>;
+};
 
 const FullScreenLoader = () => (
   <div className="min-h-screen flex items-center justify-center bg-gray-50">
@@ -36,10 +56,172 @@ const ProtectedRoute: React.FC<React.PropsWithChildren> = ({ children }) => {
 
 const Router = () => {
   const location = useLocation();
-  const { status } = useAuth();
-  const { isHydrated } = useAssessment();
+  const { status, user } = useAuth();
+  const {
+    isHydrated,
+    setSelectedRole,
+    setAssessmentResult,
+    setActiveAttempt,
+    resetAssessment,
+  } = useAssessment();
+  const [isSyncing, setIsSyncing] = React.useState(false);
 
-  if (status !== 'ready' || !isHydrated) {
+  React.useEffect(() => {
+    if (status !== 'ready' || !isHydrated) {
+      return;
+    }
+
+    if (!user) {
+      resetAssessment();
+      return;
+    }
+
+    let isMounted = true;
+
+    const syncProgress = async () => {
+      setIsSyncing(true);
+
+      try {
+        const { data, error } = await supabase
+          .from('assessment_attempts')
+          .select(
+            `
+              id,
+              role,
+              status,
+              answered_count,
+              total_questions,
+              progress_percent,
+              started_at,
+              submitted_at,
+              completed_at,
+              last_activity_at,
+              result:results(
+                id,
+                total_score,
+                score,
+                strengths
+              )
+            `,
+          )
+          .eq('profile_id', user.id)
+          .order('created_at', { ascending: false })
+          .limit(1)
+          .maybeSingle<SupabaseAttemptWithResult>();
+
+        if (!isMounted) {
+          return;
+        }
+
+        if (error) {
+          throw error;
+        }
+
+        if (!data) {
+          resetAssessment();
+          return;
+        }
+
+        setSelectedRole(
+          data.role
+            ? {
+                name: data.role,
+                title: data.role,
+              }
+            : null,
+        );
+
+        const mapAttemptRow = (row: SupabaseAttemptWithResult): AssessmentAttempt => ({
+          id: row.id,
+          status: row.status,
+          answeredCount: row.answered_count ?? 0,
+          totalQuestions: row.total_questions ?? 0,
+          progressPercent: Number(row.progress_percent ?? 0),
+          startedAt: row.started_at,
+          submittedAt: row.submitted_at,
+          completedAt: row.completed_at,
+          lastActivityAt: row.last_activity_at,
+        });
+
+        setActiveAttempt(mapAttemptRow(data));
+
+        const normaliseStrengths = (value: unknown): string[] => {
+          if (Array.isArray(value)) {
+            return value.filter((item): item is string => typeof item === 'string');
+          }
+          if (typeof value === 'string') {
+            try {
+              const parsed = JSON.parse(value) as unknown;
+              if (Array.isArray(parsed)) {
+                return parsed.filter((item): item is string => typeof item === 'string');
+              }
+            } catch (parseError) {
+              console.warn('Unable to parse strengths payload:', parseError);
+            }
+            return [value];
+          }
+          return [];
+        };
+
+        const resolveResultPayload = (attempt: SupabaseAttemptWithResult) => {
+          if (!attempt.result) {
+            return null;
+          }
+
+          const payload = Array.isArray(attempt.result) ? attempt.result[0] : attempt.result;
+
+          if (!payload) {
+            return null;
+          }
+
+          const rawScore =
+            typeof payload.total_score === 'number'
+              ? payload.total_score
+              : typeof payload.score === 'number'
+              ? payload.score
+              : null;
+
+          if (rawScore == null) {
+            return null;
+          }
+
+          return {
+            score: rawScore,
+            strengths: normaliseStrengths(payload.strengths ?? []),
+          } satisfies AssessmentResult;
+        };
+
+        const result = resolveResultPayload(data);
+        setAssessmentResult(result);
+      } catch (syncError) {
+        if (isMounted) {
+          console.error('Failed to sync assessment progress:', syncError);
+          resetAssessment();
+        }
+      } finally {
+        if (isMounted) {
+          setIsSyncing(false);
+        }
+      }
+    };
+
+    void syncProgress();
+
+    return () => {
+      isMounted = false;
+      setIsSyncing(false);
+    };
+  }, [
+    status,
+    isHydrated,
+    user,
+    setSelectedRole,
+    setAssessmentResult,
+    setActiveAttempt,
+    resetAssessment,
+  ]);
+
+  if (status !== 'ready' || !isHydrated || isSyncing) {
     return <FullScreenLoader />;
   }
 

--- a/src/contexts/AssessmentContext.tsx
+++ b/src/contexts/AssessmentContext.tsx
@@ -1,4 +1,12 @@
-﻿import { createContext, useContext, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from 'react';
 import type { Role, AssessmentResult, AssessmentAttempt } from '@/types/assessment';
 
 interface AssessmentState {
@@ -60,30 +68,30 @@ export const AssessmentProvider = ({ children }: PropsWithChildren<unknown>) => 
     }
   }, [state, isHydrated]);
 
-  const setSelectedRole = (role: Role | null) => {
+  const setSelectedRole = useCallback((role: Role | null) => {
     setState((prev) => ({
       ...prev,
       selectedRole: role,
       assessmentResult: role ? prev.assessmentResult : null,
       activeAttempt: role ? prev.activeAttempt : null,
     }));
-  };
+  }, []);
 
-  const setAssessmentResult = (result: AssessmentResult | null) => {
+  const setAssessmentResult = useCallback((result: AssessmentResult | null) => {
     setState((prev) => ({
       ...prev,
       assessmentResult: result,
     }));
-  };
+  }, []);
 
-  const setActiveAttempt = (attempt: AssessmentAttempt | null) => {
+  const setActiveAttempt = useCallback((attempt: AssessmentAttempt | null) => {
     setState((prev) => ({
       ...prev,
       activeAttempt: attempt,
     }));
-  };
+  }, []);
 
-  const updateActiveAttempt = (update: Partial<AssessmentAttempt>) => {
+  const updateActiveAttempt = useCallback((update: Partial<AssessmentAttempt>) => {
     setState((prev) => {
       if (!prev.activeAttempt) {
         return prev;
@@ -96,11 +104,11 @@ export const AssessmentProvider = ({ children }: PropsWithChildren<unknown>) => 
         },
       };
     });
-  };
+  }, []);
 
-  const resetAssessment = () => {
+  const resetAssessment = useCallback(() => {
     setState(initialState);
-  };
+  }, []);
 
   const value = useMemo(
     () => ({
@@ -112,7 +120,15 @@ export const AssessmentProvider = ({ children }: PropsWithChildren<unknown>) => 
       updateActiveAttempt,
       resetAssessment,
     }),
-    [state, isHydrated],
+    [
+      state,
+      isHydrated,
+      setSelectedRole,
+      setAssessmentResult,
+      setActiveAttempt,
+      updateActiveAttempt,
+      resetAssessment,
+    ],
   );
 
   return <AssessmentContext.Provider value={value}>{children}</AssessmentContext.Provider>;


### PR DESCRIPTION
## Summary
- memoize the assessment context setter helpers so their references stay stable between renders
- add a Supabase-backed progress sync in the router that relies on the memoized setters and clears its syncing flag once the request resolves
- gate the router loader on the syncing state and reset assessment data when no attempt is returned so the role selection screen no longer hangs

## Testing
- npm run build
- Manual authenticated-flow verification blocked (missing Supabase credentials in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68d712491d2c832c8be19211aa834eb9