### PR TITLE
Adjust assessment option handling to use API data

### DIFF
--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -14,6 +14,8 @@ export interface Question {
 export interface Option {
   id: string;
   text: string;
+  optionText?: string;
+  isCorrect?: boolean;
 }
 
 export type AnswerValue = string | number;


### PR DESCRIPTION
## Summary
- rely on API-provided option metadata when loading assessment questions
- show a fallback message when multiple-choice questions have no options available
- extend assessment option typing to expose text aliases and correctness flags

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d727494ba4832ca844484755e920ca