### PR TITLE
Fix assessment screen translations

### DIFF
--- a/src/components/AssessmentScreen.tsx
+++ b/src/components/AssessmentScreen.tsx
@@ -1,6 +1,6 @@
-﻿// src/components/AssessmentScreen.tsx
+// src/components/AssessmentScreen.tsx
 import React, { useState, useEffect, useCallback } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { ArrowLeft, ArrowRight, CheckCircle, Clock } from 'lucide-react';
 import { Button } from './ui/button';
 import { Textarea } from './ui/textarea';
@@ -310,7 +310,7 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
                 </motion.div>
               ))
             ) : (
-              <p className="text-sm text-muted-foreground">Không có đáp án</p>
+              <p className="text-sm text-muted-foreground">{t('assessmentScreen.noOptionsAvailable')}</p>
             )
           ) : (
             <Textarea
@@ -327,18 +327,20 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
   };
 
   if (loading) {
-    return <div className="text-center p-8">Äang táº£i bÃ i Ä‘Ã¡nh giÃ¡...</div>;
+    return <div className="text-center p-8">{t('assessmentScreen.loadingAssessment')}</div>;
   }
   
   if (!assessment) {
-    return <div className="text-center p-8 text-red-500">Không có bài đánh giá nào cho vai trò này.</div>;
+    return <div className="text-center p-8 text-red-500">{t('assessmentScreen.noAssessmentForRole')}</div>;
   }
 
   if (!activeAttempt) {
     return (
       <div className="text-center p-8 space-y-4">
-        <p className="text-muted-foreground">Không tìm thấy phiên làm bài hợp lệ. Vui lòng quay lại bước trước để bắt đầu lại.</p>
-        <Button onClick={() => window.history.back()} className="apple-button">Quay lại</Button>
+        <p className="text-muted-foreground">{t('assessmentScreen.noValidAttemptMessage')}</p>
+        <Button onClick={() => window.history.back()} className="apple-button">
+          {t('assessmentScreen.backButton')}
+        </Button>
       </div>
     );
   }
@@ -392,7 +394,12 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
               />
             </div>
             <div className="flex justify-between items-center mt-2 text-sm text-gray-600">
-              <span>CÃ¢u {currentQuestionIndex + 1}/{questions.length}</span>
+              <span>
+                {t('assessmentScreen.questionProgress', {
+                  current: currentQuestionIndex + 1,
+                  total: questions.length,
+                })}
+              </span>
               <span>{Math.round(((currentQuestionIndex + 1) / questions.length) * 100)}%</span>
             </div>
           </motion.div>
@@ -459,14 +466,16 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
               <svg xmlns="http://www.w3.org/2000/svg" height="40px" viewBox="0 -960 960 960" width="40px" fill="#EA3323">
                 <path d="m40-120 440-760 440 760H40Zm115.33-66.67h649.34L480-746.67l-324.67 560ZM482.78-238q14.22 0 23.72-9.62 9.5-9.61 9.5-23.83 0-14.22-9.62-23.72-9.5-14.22 0-23.72 9.62-9.62 9.5 23.83 0 14.22 9.62 23.72 9.62 9.5 23.83 9.5Zm-33.45-114H516v-216h-66.67v216ZM480-466.67Z"/>
               </svg>
-              <AlertDialogTitle>Cáº£nh bÃ¡o Gian láº­n!</AlertDialogTitle>
+              <AlertDialogTitle>{t('assessmentScreen.tabWarningTitle')}</AlertDialogTitle>
             </div>
             <AlertDialogDescription>
-              Báº¡n Ä‘Ã£ chuyá»ƒn tab trong khi lÃ m bÃ i. BÃ i kiá»ƒm tra cá»§a báº¡n sáº½ bá»‹ há»§y náº¿u báº¡n vi pháº¡m thÃªm {3 - tabViolations} láº§n ná»¯a.
+              {t('assessmentScreen.tabWarningDescription', { remaining: 3 - tabViolations })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogAction onClick={() => setIsAlertOpen(false)}>Quay láº¡i bÃ i lÃ m</AlertDialogAction>
+            <AlertDialogAction onClick={() => setIsAlertOpen(false)}>
+              {t('assessmentScreen.tabWarningAction')}
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -85,7 +85,18 @@
     "noAssessment": "This position currently has no assessment.",
     "typeYourAnswer": "Type your answer here...",
     "selectYourAnswer": "Select your answer",
-    "errorLoading": "Error loading assessment. Please try again later."
+    "errorLoading": "Error loading assessment. Please try again later.",
+    "loadingAssessment": "Loading assessment...",
+    "noAssessmentForRole": "No assessment available for this role.",
+    "noValidAttemptMessage": "No valid attempt found. Please go back to restart.",
+    "backButton": "Go back",
+    "questionProgress": "Question {current}/{total}",
+    "noOptionsAvailable": "No options available",
+    "tabWarningTitle": "Cheating Warning!",
+    "tabWarningDescription": "You switched tabs during the assessment. Your test will be cancelled if you violate {remaining} more time(s).",
+    "tabWarningAction": "Return to assessment",
+    "noQuestions": "No questions available.",
+    "errorFetching": "Failed to fetch assessment data. Please try again later."
   },
   "preAssessmentScreen": {
     "title": "Are you ready for the test?",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -85,7 +85,18 @@
     "noAssessment": "Vị trí này hiện tại không có bài đánh giá.",
     "typeYourAnswer": "Nhập câu trả lời của bạn tại đây...",
     "selectYourAnswer": "Chọn câu trả lời của bạn",
-    "errorLoading": "Lỗi tải bài đánh giá. Vui lòng thử lại sau."
+    "errorLoading": "Lỗi tải bài đánh giá. Vui lòng thử lại sau.",
+    "loadingAssessment": "Đang tải bài đánh giá...",
+    "noAssessmentForRole": "Không có bài đánh giá nào cho vai trò này.",
+    "noValidAttemptMessage": "Không tìm thấy phiên làm bài hợp lệ. Vui lòng quay lại bước trước để bắt đầu lại.",
+    "backButton": "Quay lại",
+    "questionProgress": "Câu {current}/{total}",
+    "noOptionsAvailable": "Không có đáp án",
+    "tabWarningTitle": "Cảnh báo gian lận!",
+    "tabWarningDescription": "Bạn đã chuyển tab trong khi làm bài. Bài kiểm tra của bạn sẽ bị hủy nếu bạn vi phạm thêm {remaining} lần nữa.",
+    "tabWarningAction": "Quay lại bài làm",
+    "noQuestions": "Không có câu hỏi nào.",
+    "errorFetching": "Không thể tải dữ liệu bài đánh giá. Vui lòng thử lại sau."
   },
   "preAssessmentScreen": {
     "title": "Bạn đã sẵn sàng cho bài kiểm tra chưa?",


### PR DESCRIPTION
## Summary
- replace mojibake strings on the assessment screen with localized copies via the shared i18n helper
- add missing English and Vietnamese translation keys for new assessment messages and prompts
- clean up the assessment screen header/progress messaging to use t() interpolation and localized warning dialog strings

## Testing
- npm run lint *(fails: pre-existing eslint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d728d09fbc832c8f6629371cb6a691