### PR TITLE
Handle additional Gemini JSON response formats

### DIFF
--- a/src/lib/api/assessmentMappers.ts
+++ b/src/lib/api/assessmentMappers.ts
@@ -3,6 +3,7 @@ import type { AssessmentAttemptRow } from './types';
 
 export const mapAssessmentAttempt = (row: AssessmentAttemptRow): AssessmentAttempt => ({
   id: row.id,
+  assessmentId: row.assessment_id,
   status: row.status,
   answeredCount: row.answered_count ?? 0,
   totalQuestions: row.total_questions ?? 0,
@@ -11,4 +12,6 @@ export const mapAssessmentAttempt = (row: AssessmentAttemptRow): AssessmentAttem
   submittedAt: row.submitted_at,
   completedAt: row.completed_at,
   lastActivityAt: row.last_activity_at,
+  aiStatus: (row.ai_status as AssessmentAttempt['aiStatus']) ?? null,
+  lastAiError: row.last_ai_error ?? null,
 });

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -15,5 +15,7 @@ export {
   finaliseAssessmentAttempt,
   type FinaliseAssessmentOptions,
   type FinaliseAssessmentResult,
+  getLatestResult,
+  type LatestResultRecord,
 } from './assessments';
 export { resolveAssessmentState, type AssessmentResolution } from './resolveAssessmentState';

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -56,6 +56,7 @@ export interface AssessmentAttemptRow {
   completed_at: string | null;
   last_activity_at: string | null;
   last_ai_error?: string | null;
+  ai_status?: string | null;
 }
 
 export type QuestionsByRole = Record<string, Question[]>;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -126,7 +126,14 @@
     "thankyou": "Thank you for completing!",
     "missingTitle": "We could not find your latest results yet.",
     "missingDescription": "Please complete the assessment first or refresh this page once your results are ready.",
-    "backToSelection": "Back to role selection"
+    "backToSelection": "Back to role selection",
+    "aiPendingTitle": "We're finalising your summary",
+    "aiPendingDescription": "Our AI is still analysing your responses. This usually finishes within a minute.",
+    "aiPendingCta": "Refresh result",
+    "aiFailedTitle": "We couldn’t generate your result",
+    "aiFailedDescription": "An error occurred while creating your AI summary. Please try again.",
+    "aiFailedDescriptionWithError": "An error occurred while creating your AI summary. Please try again. (Details: {error})",
+    "aiRetryCta": "Try again"
   },
   "tryoutScreen": {
     "title": "Welcome to the Tryout Center",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -126,7 +126,14 @@
     "thankyou": "Cảm ơn bạn đã hoàn thành!",
     "missingTitle": "Chúng tôi chưa thể tìm thấy kết quả mới nhất của bạn.",
     "missingDescription": "Vui lòng hoàn thành bài đánh giá trước hoặc làm mới trang này khi kết quả của bạn đã sẵn sàng.",
-    "backToSelection": "Quay lại lựa chọn vai trò"
+    "backToSelection": "Quay lại lựa chọn vai trò",
+    "aiPendingTitle": "Đang hoàn tất bản tóm tắt của bạn",
+    "aiPendingDescription": "Hệ thống AI vẫn đang phân tích câu trả lời. Thông thường quá trình này chỉ mất chưa tới một phút.",
+    "aiPendingCta": "Tải lại kết quả",
+    "aiFailedTitle": "Không thể tạo kết quả",
+    "aiFailedDescription": "Đã xảy ra lỗi khi phân tích bằng AI. Vui lòng thử lại.",
+    "aiFailedDescriptionWithError": "Đã xảy ra lỗi khi phân tích bằng AI. Vui lòng thử lại. (Chi tiết: {error})",
+    "aiRetryCta": "Thử lại"
   },
   "tryoutScreen": {
     "title": "Chào Mừng Đến Trung Tâm Thử Việc",

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -47,6 +47,7 @@ export interface AssessmentResult {
 
 export interface AssessmentAttempt {
   id: string;
+  assessmentId: string;
   status: string;
   answeredCount: number;
   totalQuestions: number;
@@ -55,4 +56,6 @@ export interface AssessmentAttempt {
   submittedAt?: string | null;
   completedAt?: string | null;
   lastActivityAt?: string | null;
+  aiStatus?: 'idle' | 'processing' | 'completed' | 'failed' | null;
+  lastAiError?: string | null;
 }


### PR DESCRIPTION
## Summary
- add resilient JSON parsing for Gemini responses including text and functionCall outputs
- preserve detailed Gemini error payloads when no structured JSON is present

## Testing
- npm run lint *(fails: existing lint errors in shared UI files)*

------
https://chatgpt.com/codex/tasks/task_b_68d733a04244832c859c3c25e64aaa51