### PR TITLE
Stabilize assessment context callbacks

### DIFF
--- a/src/contexts/AssessmentContext.tsx
+++ b/src/contexts/AssessmentContext.tsx
@@ -1,4 +1,4 @@
-﻿import { createContext, useContext, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
+﻿import { createContext, useCallback, useContext, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
 import type { Role, AssessmentResult, AssessmentAttempt } from '@/types/assessment';
 
 interface AssessmentState {
@@ -60,30 +60,30 @@ export const AssessmentProvider = ({ children }: PropsWithChildren<unknown>) => 
     }
   }, [state, isHydrated]);
 
-  const setSelectedRole = (role: Role | null) => {
+  const setSelectedRole = useCallback((role: Role | null) => {
     setState((prev) => ({
       ...prev,
       selectedRole: role,
       assessmentResult: role ? prev.assessmentResult : null,
       activeAttempt: role ? prev.activeAttempt : null,
     }));
-  };
+  }, []);
 
-  const setAssessmentResult = (result: AssessmentResult | null) => {
+  const setAssessmentResult = useCallback((result: AssessmentResult | null) => {
     setState((prev) => ({
       ...prev,
       assessmentResult: result,
     }));
-  };
+  }, []);
 
-  const setActiveAttempt = (attempt: AssessmentAttempt | null) => {
+  const setActiveAttempt = useCallback((attempt: AssessmentAttempt | null) => {
     setState((prev) => ({
       ...prev,
       activeAttempt: attempt,
     }));
-  };
+  }, []);
 
-  const updateActiveAttempt = (update: Partial<AssessmentAttempt>) => {
+  const updateActiveAttempt = useCallback((update: Partial<AssessmentAttempt>) => {
     setState((prev) => {
       if (!prev.activeAttempt) {
         return prev;
@@ -96,11 +96,11 @@ export const AssessmentProvider = ({ children }: PropsWithChildren<unknown>) => 
         },
       };
     });
-  };
+  }, []);
 
-  const resetAssessment = () => {
+  const resetAssessment = useCallback(() => {
     setState(initialState);
-  };
+  }, []);
 
   const value = useMemo(
     () => ({
@@ -112,7 +112,7 @@ export const AssessmentProvider = ({ children }: PropsWithChildren<unknown>) => 
       updateActiveAttempt,
       resetAssessment,
     }),
-    [state, isHydrated],
+    [state, isHydrated, setSelectedRole, setAssessmentResult, setActiveAttempt, updateActiveAttempt, resetAssessment],
   );
 
   return <AssessmentContext.Provider value={value}>{children}</AssessmentContext.Provider>;


### PR DESCRIPTION
## Summary
- wrap AssessmentContext mutators in useCallback to keep stable references
- ensure the provider value memo depends on the memoized callbacks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d7c79d82a4832c82892a5095785b85