### PR TITLE
Track timing metrics and cheating data for assessments

### DIFF
--- a/src/components/AssessmentScreen.tsx
+++ b/src/components/AssessmentScreen.tsx
@@ -12,6 +12,7 @@ import {
   finaliseAssessmentAttempt,
   getLatestResult,
   type FinaliseAssessmentOptions,
+  updateAssessmentAttemptMeta,
 } from '../lib/api';
 import { Role, UserAnswers, Question, AnswerValue, Assessment } from '../types/assessment';
 import { useLanguage } from '../hooks/useLanguage';
@@ -41,7 +42,9 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
   const [questions, setQuestions] = useState<Question[]>([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [userAnswers, setUserAnswers] = useState<UserAnswers>({});
-  const [answerRecords, setAnswerRecords] = useState<Record<string, { id: string; value: string }>>({});
+  const [answerRecords, setAnswerRecords] = useState<
+    Record<string, { id: string; value: string; timeSpentSeconds: number | null }>
+  >({});
   const currentQuestion = questions[currentQuestionIndex];
   const currentAnswer = userAnswers[currentQuestionIndex];
   const hasAnsweredCurrent = currentQuestion?.format === 'multiple_choice'
@@ -56,17 +59,23 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
   const [submissionError, setSubmissionError] = useState<string | null>(null);
   const finalisePayloadRef = useRef<FinaliseAssessmentOptions | null>(null);
   const isMountedRef = useRef(true);
+  const questionStartTimeRef = useRef<number | null>(null);
+  const activeQuestionIdRef = useRef<string | null>(null);
+  const questionTimeSpentRef = useRef<Record<string, number>>({});
 
   const ensureAnswerPersisted = useCallback(
-    async (questionIndex: number, overrideRawValue?: AnswerValue) => {
+    async (
+      questionIndex: number,
+      options?: { overrideRawValue?: AnswerValue; timeSpentSeconds?: number | null },
+    ) => {
       const question = questions[questionIndex];
       if (!question || !activeAttempt) {
         return;
       }
 
       const rawValue =
-        typeof overrideRawValue !== 'undefined'
-          ? overrideRawValue
+        typeof options?.overrideRawValue !== 'undefined'
+          ? options.overrideRawValue
           : userAnswers[questionIndex];
 
       if (
@@ -97,8 +106,24 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
         persistedValue = textValue;
       }
 
+      const storedTime = questionTimeSpentRef.current[question.id];
+      const timeSpentOverride =
+        typeof options?.timeSpentSeconds === 'number'
+          ? options.timeSpentSeconds
+          : typeof storedTime === 'number'
+            ? storedTime
+            : null;
+      const normalisedTimeSpent =
+        typeof timeSpentOverride === 'number'
+          ? Math.max(0, Math.round(timeSpentOverride))
+          : null;
+
       const existingRecord = answerRecords[question.id];
-      if (existingRecord && existingRecord.value === persistedValue) {
+      const shouldUpdateTime =
+        typeof normalisedTimeSpent === 'number' &&
+        normalisedTimeSpent !== (existingRecord?.timeSpentSeconds ?? null);
+
+      if (existingRecord && existingRecord.value === persistedValue && !shouldUpdateTime) {
         return;
       }
 
@@ -109,12 +134,23 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
           questionId: question.id,
           selectedOptionId,
           userAnswerText,
+          timeSpentSeconds:
+            typeof normalisedTimeSpent === 'number' ? normalisedTimeSpent : undefined,
         });
 
         if (result?.id) {
           setAnswerRecords((prev) => ({
             ...prev,
-            [question.id]: { id: result.id, value: persistedValue },
+            [question.id]: {
+              id: result.id,
+              value: persistedValue,
+              timeSpentSeconds:
+                typeof result.time_spent_seconds === 'number'
+                  ? result.time_spent_seconds
+                  : typeof normalisedTimeSpent === 'number'
+                    ? normalisedTimeSpent
+                    : existingRecord?.timeSpentSeconds ?? null,
+            },
           }));
           updateActiveAttempt({ lastActivityAt: new Date().toISOString() });
         }
@@ -124,12 +160,80 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
     },
     [activeAttempt, answerRecords, questions, updateActiveAttempt, userAnswers],
   );
+  const getTimeSpentForQuestion = useCallback(
+    (questionIndex: number): number | null => {
+      const question = questions[questionIndex];
+      if (!question) {
+        return null;
+      }
+      const stored = questionTimeSpentRef.current[question.id];
+      return typeof stored === 'number' ? stored : null;
+    },
+    [questions],
+  );
+
+  const accumulateTimeForQuestion = useCallback(
+    (questionIndex: number): number | null => {
+      const question = questions[questionIndex];
+      if (!question) {
+        return null;
+      }
+
+      const startTimestamp = questionStartTimeRef.current;
+      if (typeof startTimestamp !== 'number') {
+        return getTimeSpentForQuestion(questionIndex);
+      }
+
+      const elapsedSeconds = Math.max(0, Math.round((Date.now() - startTimestamp) / 1000));
+      const previousTotal = questionTimeSpentRef.current[question.id] ?? 0;
+      const newTotal = previousTotal + elapsedSeconds;
+      questionTimeSpentRef.current[question.id] = newTotal;
+      questionStartTimeRef.current = null;
+      return newTotal;
+    },
+    [getTimeSpentForQuestion, questions],
+  );
+
+  const calculateTotalDuration = useCallback(() => {
+    return Object.values(questionTimeSpentRef.current).reduce((sum, value) => {
+      return sum + (typeof value === 'number' ? value : 0);
+    }, 0);
+  }, []);
+
   const persistAllAnswers = useCallback(async () => {
     if (!activeAttempt) {
       return;
     }
-    await Promise.all(questions.map((_, index) => ensureAnswerPersisted(index)));
-  }, [activeAttempt, questions, ensureAnswerPersisted]);
+
+    await Promise.all(
+      questions.map((_, index) => {
+        const timeSpent = getTimeSpentForQuestion(index);
+        return ensureAnswerPersisted(index, {
+          timeSpentSeconds: typeof timeSpent === 'number' ? timeSpent : undefined,
+        });
+      }),
+    );
+  }, [activeAttempt, ensureAnswerPersisted, getTimeSpentForQuestion, questions]);
+
+  const persistCheatingCount = useCallback(
+    async (count: number) => {
+      if (!activeAttempt) {
+        return;
+      }
+
+      if (activeAttempt.cheatingCount === count) {
+        return;
+      }
+
+      try {
+        await updateAssessmentAttemptMeta(activeAttempt.id, { cheatingCount: count });
+        updateActiveAttempt({ cheatingCount: count });
+      } catch (error) {
+        console.error('Failed to update cheating count for attempt', activeAttempt.id, error);
+      }
+    },
+    [activeAttempt, updateActiveAttempt],
+  );
 
   useEffect(() => {
     return () => {
@@ -137,6 +241,32 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
       finalisePayloadRef.current = null;
     };
   }, []);
+
+  useEffect(() => {
+    setTabViolations(activeAttempt?.cheatingCount ?? 0);
+  }, [activeAttempt?.cheatingCount]);
+
+  useEffect(() => {
+    questionTimeSpentRef.current = {};
+    questionStartTimeRef.current = null;
+    activeQuestionIdRef.current = null;
+  }, [activeAttempt?.id]);
+
+  useEffect(() => {
+    const question = questions[currentQuestionIndex];
+    if (!question) {
+      activeQuestionIdRef.current = null;
+      questionStartTimeRef.current = null;
+      return;
+    }
+
+    if (activeQuestionIdRef.current !== question.id) {
+      activeQuestionIdRef.current = question.id;
+      questionStartTimeRef.current = Date.now();
+    } else if (questionStartTimeRef.current === null) {
+      questionStartTimeRef.current = Date.now();
+    }
+  }, [currentQuestionIndex, questions]);
 
   const runAiAnalysis = useCallback(async () => {
     const payload = finalisePayloadRef.current;
@@ -246,7 +376,17 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
       return;
     }
 
+    const latestTime = accumulateTimeForQuestion(currentQuestionIndex);
+    await ensureAnswerPersisted(currentQuestionIndex, {
+      timeSpentSeconds: typeof latestTime === 'number' ? latestTime : undefined,
+    });
     await persistAllAnswers();
+    await persistCheatingCount(tabViolations);
+
+    const totalDurationSeconds = calculateTotalDuration();
+    const totalQuestions = questions.length || activeAttempt.totalQuestions || 0;
+    const averageSecondsPerQuestion =
+      totalQuestions > 0 ? totalDurationSeconds / totalQuestions : null;
 
     if (isMountedRef.current) {
       setSubmissionError(null);
@@ -254,7 +394,11 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
     }
 
     try {
-      const updatedAttempt = await submitAssessmentAttempt(activeAttempt.id);
+      const updatedAttempt = await submitAssessmentAttempt(activeAttempt.id, {
+        durationSeconds: totalDurationSeconds,
+        averageSecondsPerQuestion,
+        cheatingCount: tabViolations,
+      });
       updateActiveAttempt(updatedAttempt);
 
       const answersForGemini = questions
@@ -333,10 +477,16 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
     getAiErrorMessage,
     lang,
     onFinish,
+    accumulateTimeForQuestion,
+    calculateTotalDuration,
+    currentQuestionIndex,
+    ensureAnswerPersisted,
     persistAllAnswers,
+    persistCheatingCount,
     questions,
     role.name,
     runAiAnalysis,
+    tabViolations,
     updateActiveAttempt,
     user,
     userAnswers,
@@ -363,6 +513,24 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
   const isAttemptSubmitted = Boolean(activeAttempt?.submittedAt);
 
   useEffect(() => {
+    if (!activeAttempt || isAttemptSubmitted) {
+      return;
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = 'Changes you made may not be saved.';
+      return 'Changes you made may not be saved.';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [activeAttempt, isAttemptSubmitted]);
+
+  useEffect(() => {
     if (isFinalising || isAttemptSubmitted) {
       return;
     }
@@ -372,7 +540,11 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
         return;
       }
 
-      setTabViolations((prev) => prev + 1);
+      setTabViolations((prev) => {
+        const next = prev + 1;
+        void persistCheatingCount(next);
+        return next;
+      });
       setIsAlertOpen(true);
     };
 
@@ -381,13 +553,13 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [isFinalising, isAttemptSubmitted]);
+  }, [isFinalising, isAttemptSubmitted, persistCheatingCount]);
 
   useEffect(() => {
-    if (tabViolations >= 3) {
+    if (tabViolations >= 3 && !isAttemptSubmitted) {
       void finishAssessment();
     }
-  }, [tabViolations, finishAssessment]);
+  }, [tabViolations, finishAssessment, isAttemptSubmitted]);
 
   const saveAnswer = (questionIndex: number, answer: AnswerValue) => {
     setUserAnswers((prev) => ({
@@ -403,13 +575,21 @@ const AssessmentScreen: React.FC<AssessmentScreenProps> = ({ role, onFinish }) =
 
   const navigateQuestion = useCallback(
     async (direction: number) => {
-      await ensureAnswerPersisted(currentQuestionIndex);
       const newIndex = currentQuestionIndex + direction;
       if (newIndex >= 0 && newIndex < questions.length) {
+        const timeSpent = accumulateTimeForQuestion(currentQuestionIndex);
+        await ensureAnswerPersisted(currentQuestionIndex, {
+          timeSpentSeconds: typeof timeSpent === 'number' ? timeSpent : undefined,
+        });
         setCurrentQuestionIndex(newIndex);
       }
     },
-    [currentQuestionIndex, questions.length, ensureAnswerPersisted],
+    [
+      accumulateTimeForQuestion,
+      currentQuestionIndex,
+      ensureAnswerPersisted,
+      questions.length,
+    ],
   );
 
   // Fetch assessment data from API

--- a/src/lib/api/assessmentMappers.ts
+++ b/src/lib/api/assessmentMappers.ts
@@ -14,4 +14,7 @@ export const mapAssessmentAttempt = (row: AssessmentAttemptRow): AssessmentAttem
   lastActivityAt: row.last_activity_at,
   aiStatus: (row.ai_status as AssessmentAttempt['aiStatus']) ?? null,
   lastAiError: row.last_ai_error ?? null,
+  durationSeconds: row.duration_seconds ?? null,
+  averageSecondsPerQuestion: row.average_seconds_per_question ?? null,
+  cheatingCount: row.cheating_count ?? 0,
 });

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -17,5 +17,6 @@ export {
   type FinaliseAssessmentResult,
   getLatestResult,
   type LatestResultRecord,
+  updateAssessmentAttemptMeta,
 } from './assessments';
 export { resolveAssessmentState, type AssessmentResolution } from './resolveAssessmentState';

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -27,10 +27,12 @@ export interface CandidateInfo {
 export interface AnswerRow {
   id: string;
   result_id: string | null;
+  attempt_id?: string | null;
   question_id: string;
   user_answer_text: string | null;
   selected_option_id: string | null;
   created_at: string;
+  time_spent_seconds?: number | null;
 }
 
 export interface AnswerInput {
@@ -40,6 +42,7 @@ export interface AnswerInput {
   questionId: string;
   userAnswerText?: string | null;
   selectedOptionId?: string | null;
+  timeSpentSeconds?: number | null;
 }
 
 export interface AssessmentAttemptRow {
@@ -57,6 +60,9 @@ export interface AssessmentAttemptRow {
   last_activity_at: string | null;
   last_ai_error?: string | null;
   ai_status?: string | null;
+  duration_seconds?: number | null;
+  average_seconds_per_question?: number | null;
+  cheating_count?: number | null;
 }
 
 export type QuestionsByRole = Record<string, Question[]>;

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -72,5 +72,8 @@ export interface AssessmentAttempt {
   lastActivityAt?: string | null;
   aiStatus?: 'idle' | 'processing' | 'completed' | 'failed' | null;
   lastAiError?: string | null;
+  durationSeconds?: number | null;
+  averageSecondsPerQuestion?: number | null;
+  cheatingCount?: number;
 }
 


### PR DESCRIPTION
## Summary
- record per-question answer time and link answer records to the active attempt
- persist attempt duration, average time per question, and cheating counts when submitting assessments
- warn candidates before closing the tab and sync cheating violations triggered by tab changes

## Testing
- npm run lint *(fails due to existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d8b468edd4832ca3fdd09f7b99aff4